### PR TITLE
Docker: Apply Drizzle schema on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR /app
 
 # Vars de build côté client (optionnelles, préfixées VITE_)
 ARG VITE_FRONTEND_URL
+ARG VITE_API_DERBY
 ARG CAPROVER_GIT_COMMIT_SHA
 ENV VITE_FRONTEND_URL=$VITE_FRONTEND_URL
+ENV VITE_API_DERBY=$VITE_API_DERBY
 ENV CAPROVER_GIT_COMMIT_SHA=$CAPROVER_GIT_COMMIT_SHA
 
 # pnpm via corepack (comme dans ton exemple)
@@ -24,9 +26,7 @@ COPY . .
 
 ENV NODE_ENV=production
 
-# Génère le .env à partir de .env.exemple AVANT le build,
-# en utilisant les variables d'environnement (DATABASE_URL, EMAIL_API_KEY, etc.)
-RUN pnpm env:from-example && pnpm run db:push && pnpm build
+RUN pnpm build
 
 #########################
 # STAGE 2 : RUNTIME SSR #
@@ -36,17 +36,19 @@ FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
 
-# On copie uniquement ce dont Nitro a besoin :
+# On copie le bundle Nitro et les fichiers nécessaires au push Drizzle :
 # - le bundle serveur dans .output
 # - les dépendances Node
 # - package.json (pour info / tooling éventuel)
 COPY --from=builder /app/.output ./.output
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=builder /app/src/db ./src/db
 
 EXPOSE 3000
 ENV PORT=3000
 ENV HOST=0.0.0.0
 
-# On lance le serveur Node Nitro généré par SolidStart
-CMD ["node", ".output/server/index.mjs"]
+# On applique le schéma au démarrage, quand les variables runtime CapRover sont disponibles.
+CMD ["sh", "-c", "./node_modules/.bin/drizzle-kit push && node .output/server/index.mjs"]


### PR DESCRIPTION
Moves the Drizzle database schema application from build time to container runtime.
This ensures environment variables like `DATABASE_URL` are available when the schema is applied.
Also introduces `VITE_API_DERBY` as a build argument and environment variable.
