### PR TITLE
fix(deps): upgrade vulnerable dependencies (issue #21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.15.4",
-    "@solidjs/start": "^1.2.1",
+    "@solidjs/start": "^1.3.2",
     "dotenv": "^17.2.3",
-    "drizzle-orm": "^0.44.7",
+    "drizzle-orm": "^0.45.2",
     "marked": "^18.0.2",
     "mysql2": "^3.16.1",
     "solid-js": "^1.9.10",
@@ -39,11 +39,11 @@
     "@playwright/test": "1.61.1",
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^24.10.9",
-    "drizzle-kit": "^0.31.8",
+    "drizzle-kit": "^0.31.10",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
     "typescript": "5.9.2",
-    "vite": "6.4.3"
+    "vite": "^7.2.0"
   },
   "engines": {
     "node": ">=22"
@@ -63,9 +63,12 @@
       "serialize-javascript": ">=7.0.5",
       "node-forge": ">=1.4.0",
       "picomatch": ">=4.0.4",
+      "brace-expansion": ">=5.0.7",
       "brace-expansion@2": ">=2.0.3",
       "lodash": ">=4.18.0",
-      "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
+      "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1",
+      "defu": ">=6.1.5",
+      "postcss": ">=8.5.12"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,12 @@ overrides:
   serialize-javascript: '>=7.0.5'
   node-forge: '>=1.4.0'
   picomatch: '>=4.0.4'
+  brace-expansion: '>=5.0.7'
   brace-expansion@2: '>=2.0.3'
   lodash: '>=4.18.0'
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
+  defu: '>=6.1.5'
+  postcss: '>=8.5.12'
 
 importers:
 
@@ -33,14 +36,14 @@ importers:
         specifier: ^0.15.4
         version: 0.15.4(solid-js@1.9.10)
       '@solidjs/start':
-        specifier: ^1.2.1
-        version: 1.2.1(solid-js@1.9.10)(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+        specifier: ^1.3.2
+        version: 1.3.2(solid-js@1.9.10)(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
       drizzle-orm:
-        specifier: ^0.44.7
-        version: 0.44.7(mysql2@3.16.1)
+        specifier: ^0.45.2
+        version: 0.45.2(mysql2@3.16.1)
       marked:
         specifier: ^18.0.2
         version: 18.0.2
@@ -52,7 +55,7 @@ importers:
         version: 1.9.10
       vinxi:
         specifier: ^0.5.11
-        version: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
+        version: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
     devDependencies:
       '@axe-core/playwright':
         specifier: 4.12.1
@@ -65,13 +68,13 @@ importers:
         version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+        version: 4.1.18(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
       '@types/node':
         specifier: ^24.10.9
         version: 24.10.9
       drizzle-kit:
-        specifier: ^0.31.8
-        version: 0.31.8
+        specifier: ^0.31.10
+        version: 0.31.10
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -82,8 +85,8 @@ importers:
         specifier: 5.9.2
         version: 5.9.2
       vite:
-        specifier: 6.4.3
-        version: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
+        specifier: ^7.2.0
+        version: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
 
 packages:
 
@@ -198,11 +201,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -984,8 +987,8 @@ packages:
     peerDependencies:
       solid-js: ^1.8.6
 
-  '@solidjs/start@1.2.1':
-    resolution: {integrity: sha512-O5E7rcCwm2f8GlXKgS2xnU37Ld5vMVXJgo/qR7UI5iR5uFo9V2Ac+SSVNXkM98CeHKHt55h1UjbpxxTANEsHmA==}
+  '@solidjs/start@1.3.2':
+    resolution: {integrity: sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==}
     peerDependencies:
       vinxi: ^0.5.7
 
@@ -1144,6 +1147,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/nft@1.3.0':
     resolution: {integrity: sha512-i4EYGkCsIjzu4vorDUbqglZc5eFtQI2syHb++9ZUDm6TU4edVywGpVnYDein35x9sevONOn9/UabfQXuNXtuzQ==}
@@ -1324,9 +1328,6 @@ packages:
       solid-js:
         optional: true
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1390,12 +1391,9 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1564,9 +1562,6 @@ packages:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1701,9 +1696,6 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
-
   defu@6.1.6:
     resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
@@ -1759,12 +1751,12 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.31.8:
-    resolution: {integrity: sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==}
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.44.7:
-    resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -1922,11 +1914,6 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
-
-  esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.25.0'
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -2746,8 +2733,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2961,8 +2948,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-bytes@7.1.0:
@@ -3730,6 +3717,46 @@ packages:
       yaml:
         optional: true
 
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.1:
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
@@ -4017,7 +4044,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.2
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -4639,13 +4666,13 @@ snapshots:
     dependencies:
       solid-js: 1.9.10
 
-  '@solidjs/start@1.2.1(solid-js@1.9.10)(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
+  '@solidjs/start@1.3.2(solid-js@1.9.10)(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
-      '@tanstack/server-functions-plugin': 1.121.21(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
+      '@tanstack/server-functions-plugin': 1.121.21(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
       cookie-es: 2.0.0
-      defu: 6.1.4
+      defu: 6.1.6
       error-stack-parser: 2.1.4
       html-to-image: 1.11.13
       radix3: 1.1.2
@@ -4655,8 +4682,8 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.10)
       tinyglobby: 0.2.15
-      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
-      vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
+      vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -4726,14 +4753,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
 
-  '@tanstack/directive-functions-plugin@1.121.21(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
+  '@tanstack/directive-functions-plugin@1.121.21(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.6
@@ -4742,7 +4769,7 @@ snapshots:
       '@tanstack/router-utils': 1.154.7
       babel-dead-code-elimination: 1.0.12
       tiny-invariant: 1.3.3
-      vite: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4758,7 +4785,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/server-functions-plugin@1.121.21(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
+  '@tanstack/server-functions-plugin@1.121.21(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.6
@@ -4767,7 +4794,7 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
-      '@tanstack/directive-functions-plugin': 1.121.21(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+      '@tanstack/directive-functions-plugin': 1.121.21(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
       babel-dead-code-elimination: 1.0.12
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -4854,7 +4881,7 @@ snapshots:
       citty: 0.1.6
       clipboardy: 4.0.0
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.6
       get-port-please: 3.2.0
       h3: 1.15.11
       http-shutdown: 1.2.2
@@ -4867,7 +4894,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.2
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@babel/parser': 7.28.6
       acorn: 8.15.0
@@ -4878,18 +4905,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
+      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0))
       acorn: 8.15.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.15.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
+      vinxi: 0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0)
 
   abbrev@3.0.1: {}
 
@@ -5032,8 +5059,6 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.10
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
@@ -5107,12 +5132,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5145,7 +5165,7 @@ snapshots:
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.2
-      defu: 6.1.4
+      defu: 6.1.6
       dotenv: 17.2.3
       exsolve: 1.0.8
       giget: 2.0.0
@@ -5304,8 +5324,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  concat-map@0.0.1: {}
-
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
@@ -5371,9 +5389,9 @@ snapshots:
       '@deno/shim-deno': 0.19.2
       undici-types: 5.28.4
 
-  db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1):
+  db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1):
     optionalDependencies:
-      drizzle-orm: 0.44.7(mysql2@3.16.1)
+      drizzle-orm: 0.45.2(mysql2@3.16.1)
       mysql2: 3.16.1
 
   debug@2.6.9:
@@ -5391,8 +5409,6 @@ snapshots:
   deepmerge@4.3.1: {}
 
   define-lazy-prop@2.0.0: {}
-
-  defu@6.1.4: {}
 
   defu@6.1.6: {}
 
@@ -5434,16 +5450,14 @@ snapshots:
 
   dotenv@17.2.3: {}
 
-  drizzle-kit@0.31.8:
+  drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.12
-      esbuild-register: 3.6.0(esbuild@0.25.12)
-    transitivePeerDependencies:
-      - supports-color
+      tsx: 4.21.0
 
-  drizzle-orm@0.44.7(mysql2@3.16.1):
+  drizzle-orm@0.45.2(mysql2@3.16.1):
     optionalDependencies:
       mysql2: 3.16.1
 
@@ -5502,13 +5516,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  esbuild-register@3.6.0(esbuild@0.25.12):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.25.12
-    transitivePeerDependencies:
-      - supports-color
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5802,7 +5809,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.6
       node-fetch-native: 1.6.7
       nypm: 0.6.4
       pathe: 2.0.3
@@ -6227,7 +6234,7 @@ snapshots:
       clipboardy: 4.0.0
       consola: 3.4.2
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.6
       get-port-please: 3.2.0
       h3: 1.15.11
       http-shutdown: 1.2.2
@@ -6378,11 +6385,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -6427,7 +6434,7 @@ snapshots:
     dependencies:
       lru.min: 1.1.3
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   negotiator@0.6.3: {}
 
@@ -6435,7 +6442,7 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  nitropack@2.13.1(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1):
+  nitropack@2.13.1(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
@@ -6456,8 +6463,8 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1)
-      defu: 6.1.4
+      db0: 0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1)
+      defu: 6.1.6
       destr: 2.0.5
       dot-prop: 10.1.0
       esbuild: 0.27.2
@@ -6502,7 +6509,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.6.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2)
+      unstorage: 1.17.4(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0-beta.13
@@ -6708,9 +6715,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.6:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6788,7 +6795,7 @@ snapshots:
 
   rc9@2.1.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.6
       destr: 2.0.5
 
   readable-stream@2.3.8:
@@ -6987,7 +6994,7 @@ snapshots:
 
   serve-placeholder@2.0.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.6
 
   serve-static@1.16.3:
     dependencies:
@@ -7362,7 +7369,7 @@ snapshots:
   unenv@1.10.0:
     dependencies:
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.6
       mime: 3.0.0
       node-fetch-native: 1.6.7
       pathe: 1.1.2
@@ -7431,7 +7438,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.4(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2):
+  unstorage@1.17.4(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -7442,7 +7449,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
-      db0: 0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1)
+      db0: 0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1)
       ioredis: 5.9.2
 
   untun@0.1.3:
@@ -7454,7 +7461,7 @@ snapshots:
   untyped@2.0.0:
     dependencies:
       citty: 0.1.6
-      defu: 6.1.4
+      defu: 6.1.6
       jiti: 2.6.1
       knitwork: 1.3.0
       scule: 1.3.0
@@ -7494,7 +7501,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.44.7(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0):
+  vinxi@0.5.11(@types/node@24.10.9)(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(drizzle-orm@0.45.2(mysql2@3.16.1))(ioredis@5.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(mysql2@3.16.1)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
@@ -7507,7 +7514,7 @@ snapshots:
       consola: 3.4.2
       crossws: 0.3.5
       dax-sh: 0.43.2
-      defu: 6.1.4
+      defu: 6.1.6
       es-module-lexer: 1.7.0
       esbuild: 0.25.12
       get-port-please: 3.2.0
@@ -7515,7 +7522,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.1(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1)
+      nitropack: 2.13.1(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -7527,7 +7534,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unenv: 1.10.0
-      unstorage: 1.17.4(db0@0.3.4(drizzle-orm@0.44.7(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2)
+      unstorage: 1.17.4(db0@0.3.4(drizzle-orm@0.45.2(mysql2@3.16.1))(mysql2@3.16.1))(ioredis@5.9.2)
       vite: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
       zod: 4.3.6
     transitivePeerDependencies:
@@ -7575,7 +7582,7 @@ snapshots:
       - xml2js
       - yaml
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)):
     dependencies:
       '@babel/core': 7.28.6
       '@types/babel__core': 7.20.5
@@ -7583,8 +7590,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)
-      vite: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
+      vitefu: 1.1.1(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -7593,7 +7600,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.22
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -7604,9 +7611,25 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
 
-  vitefu@1.1.1(vite@6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)):
+  vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.22
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
     optionalDependencies:
-      vite: 6.4.3(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
+      '@types/node': 24.10.9
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      terser: 5.46.0
+      tsx: 4.21.0
+
+  vitefu@1.1.1(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)
 
   webdriver-bidi-protocol@0.4.1: {}
 


### PR DESCRIPTION
## Ticket
Closes #21

## Contexte
Le harnais qualité #20 a signalé 4 vulnérabilités hautes restantes via `pnpm audit --audit-level high` :
- `defu ≤ 6.1.4` (prototype pollution, CVE-2026-35209) via @solidjs/start ;
- `drizzle-orm < 0.45.2` (injection SQL via identifiants échappés, CVE-2026-39356) ;
- `brace-expansion < 5.0.7` (DoS par expansion exponentielle, CVE-2026-13149) via vinxi > nitropack > @vercel/nft ;
- `postcss ≤ 8.5.11` (lecture arbitraire de fichier, GHSA-6g55-p6wh-862q) via Vite.

## Solution
- Bump `@solidjs/start` 1.2.1 → 1.3.2 (remonte defu 6.1.6).
- Bump `drizzle-orm` 0.44.7 → 0.45.2 ; `drizzle-kit` 0.31.8 → 0.31.10.
- Bump `vite` 6.4.3 → ^7.2.0 (remonte postcss ≥ 8.5.12).
- Overrides pnpm : `brace-expansion ≥ 5.0.7`, `defu ≥ 6.1.5`, `postcss ≥ 8.5.12`.

Aucun changement de code applicatif : les requêtes utilisent exclusivement des helpers Drizzle statiques (`eq`, `and`, `or`, `sql` avec littéraux), le correctif d'\''échappement d'\''identifiant n'\''affecte aucun site d'\''appel.

## Critères d'\''acceptation
- [x] SolidStart, Drizzle, Vinxi/Vite et Tailwind mis à niveau vers des versions corrigées.
- [x] `pnpm audit --audit-level high` ne signale plus de vulnérabilité haute ou critique.
- [x] `pnpm run test:ci` passe (typecheck + unit + build + e2e).
- [ ] `pnpm run audit:lighthouse` : à valider en CI (job dédié, budget inchangé).
- [x] Migrations / changements d'\''API Drizzle-SolidStart — non applicables : aucune API touchée.

## Scénario Gherkin
```
Scenario: Les dépendances de production ne présentent pas de vulnérabilité majeure connue
  Given le lockfile de production est installé
  When l'\''audit des dépendances est exécuté
  Then aucune vulnérabilité haute ou critique n'\''est signalée
  And les tests applicatifs et non fonctionnels passent
```

## Tests
- `pnpm audit --audit-level high` : 0 high / 0 critical.
- `pnpm run test:ci` : OK.
- Versions installées : defu@6.1.6, brace-expansion@5.0.8, postcss@8.5.22, drizzle-orm@0.45.2.

## Risques / rollback
Risque Drizzle : bump de patch (0.44.7 → 0.45.2) sans changement d'\''API publique utilisé.
Risque Vite : bump majeur 6 → 7. Validation via le build Vinxi et le smoke Playwright. Rollback via revert du commit + regénération du lockfile.